### PR TITLE
fix(config): intuitive file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tefe": "./dist/bin/tefe.js"
   },
   "description": "A CLI for FE engineers",
-  "main": "./src/index.js",
+  "main": "./dist/index.js",
   "keywords": [
     "cli",
     "telicent"

--- a/src/hookPostinstall/check/findWorkflowNpmInstallCommands.test.ts
+++ b/src/hookPostinstall/check/findWorkflowNpmInstallCommands.test.ts
@@ -25,7 +25,7 @@ vi.mock('chalk', () => ({
   },
 }))
 
-import { findWorkflowNpmInstallCommands } from './findWorkflowNpmInstallCommands'
+import { findWorkflowNpmInstallCommands } from './findWorkflowNpmInstallCommands.js'
 
 let consoleOutput: string[] = []
 const mockedConsoleError = (output: string) => consoleOutput.push(output)

--- a/src/hookPostinstall/check/tryWritePrecommit.test.ts
+++ b/src/hookPostinstall/check/tryWritePrecommit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
 import { fs as memfs, vol } from 'memfs'
-import { tryWritePrecommit } from './tryWritePrecommit' // Adjust the import path as needed
+import { tryWritePrecommit } from './tryWritePrecommit.js' // Adjust the import path as needed
 
 vi.mock('fs', () => ({
   default: {

--- a/src/hookPrecommit/check/writePullRequestTemplate.test.ts
+++ b/src/hookPrecommit/check/writePullRequestTemplate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
 import { fs as memfs, vol } from 'memfs'
-import { writePullRequestTemplate } from './writePullRequestTemplate' // Adjust the import path as needed
+import { writePullRequestTemplate } from './writePullRequestTemplate.js' // Adjust the import path as needed
 
 // Mocking filesystem and path utilities
 vi.mock('fs', () => ({

--- a/src/npmrcAuthToken/utils/extractTokens.test.ts
+++ b/src/npmrcAuthToken/utils/extractTokens.test.ts
@@ -1,6 +1,6 @@
 import { vi, test, expect } from 'vitest'
-import { extractTokens } from './extractTokens'
-import * as authTokenModule from './authTokenPattern'
+import { extractTokens } from './extractTokens.js'
+import * as authTokenModule from './authTokenPattern.js'
 
 test(`extractTokens`, () => {
   expect(

--- a/src/npmrcAuthToken/utils/findFile.test.ts
+++ b/src/npmrcAuthToken/utils/findFile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { findFile } from './findFile' // Adjust the import path as necessary
+import { findFile } from './findFile.js' // Adjust the import path as necessary
 import * as fs from 'fs'
 import * as path from 'path'
 

--- a/src/npmrcAuthToken/utils/mask.test.ts
+++ b/src/npmrcAuthToken/utils/mask.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { mask } from './mask'
+import { mask } from './mask.js'
 
 test(`mask`, () => {
   expect(mask('1234123411234')).toMatchInlineSnapshot(`"1234*********"`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "target": "es2020",                 // Node 16 supports ES2020 features
-    "module": "ESNext",                 // Use the latest module standard that Node supports
+    "module": "ES2022",                 // Use ES2022 for import.meta support
     "moduleResolution": "node",         // Use Node.js style module resolution
+    "allowImportingTsExtensions": false,
+    "noEmit": false,
     "esModuleInterop": true,            // Enable interop between default and named imports
     "outDir": "./dist",                 // Output directory for compiled files
     "rootDir": "./src",                 // Root directory of source files


### PR DESCRIPTION
Ticket: None. 30 minute unticketed work

### Goal

**Before**: Import `.js` files in ts

**After**: Ts import `.ts` files

### Work Completed

**Before**: ESM-style imports with explicit .js extensions

**After**: Normal TS import behavior

### Testing

```
yarn link
bh tefe version
bh tefe info
```

